### PR TITLE
Set all impacts to 0.5

### DIFF
--- a/controls/eks-cis-4.2.6.rb
+++ b/controls/eks-cis-4.2.6.rb
@@ -34,8 +34,8 @@ service accounts and users are given permission to access that PSP.
   desc 'fix', "Create a PSP as described in the Kubernetes documentation,
 ensuring that the `.spec.runAsUser.rule` is set to either `MustRunAsNonRoot` or
 `MustRunAs` with the range of UIDs not including 0."
-  impact 0.7
-  tag severity: 'high'
+  impact 0.5
+  tag severity: 'medium'
   tag gtitle: nil
   tag gid: nil
   tag rid: nil


### PR DESCRIPTION
CIS benchmarks don't really have a High, Medium, Low vulnerability severity context. Their Levels 1, 2 refer to complexity of implementation of a configuration setting, not the severity of the vulnerability to a system that doesn't implement the setting in question. Our early cis-to-inspec stub-out code inadvertantly mapped these levels to medium (0.5) and high (0.7).

This branch/PR corrects this by setting all impacts to 0.5 and severity tag to medium. (just "down the middle / even for all")